### PR TITLE
Add an API to access the packed size of a given type.

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -17,7 +17,7 @@ func clearCaches() {
 	unpackerCache.Lock()
 	defer unpackerCache.Unlock()
 
-	packerCache.m = make(map[reflect.Type]packer)
+	packerCache.m = make(map[reflect.Type]cachedPacker)
 	unpackerCache.m = make(map[reflect.Type]unpacker)
 }
 
@@ -31,7 +31,7 @@ func BenchmarkBool1Field(b *testing.B) {
 		F1 bool
 	}
 
-	p := makePackerWrapper(reflect.TypeOf(typ{}))
+	p, _ := makePackerWrapper(reflect.TypeOf(typ{}))
 	bytes := make([]byte, 1)
 	val := reflect.ValueOf(typ{})
 	b.ResetTimer()
@@ -45,7 +45,7 @@ func BenchmarkBool2Fields(b *testing.B) {
 		F1, F2 bool
 	}
 
-	p := makePackerWrapper(reflect.TypeOf(typ{}))
+	p, _ := makePackerWrapper(reflect.TypeOf(typ{}))
 	bytes := make([]byte, 1)
 	val := reflect.ValueOf(typ{})
 	b.ResetTimer()
@@ -59,7 +59,7 @@ func BenchmarkBool4Fields(b *testing.B) {
 		F1, F2, F3, F4 bool
 	}
 
-	p := makePackerWrapper(reflect.TypeOf(typ{}))
+	p, _ := makePackerWrapper(reflect.TypeOf(typ{}))
 	bytes := make([]byte, 1)
 	val := reflect.ValueOf(typ{})
 	b.ResetTimer()
@@ -73,7 +73,7 @@ func BenchmarkBool8Fields(b *testing.B) {
 		F1, F2, F3, F4, F5, F6, F7, F8 bool
 	}
 
-	p := makePackerWrapper(reflect.TypeOf(typ{}))
+	p, _ := makePackerWrapper(reflect.TypeOf(typ{}))
 	bytes := make([]byte, 1)
 	val := reflect.ValueOf(typ{})
 	b.ResetTimer()
@@ -87,7 +87,7 @@ func BenchmarkBool9Fields(b *testing.B) {
 		F1, F2, F3, F4, F5, F6, F7, F8, F9 bool
 	}
 
-	p := makePackerWrapper(reflect.TypeOf(typ{}))
+	p, _ := makePackerWrapper(reflect.TypeOf(typ{}))
 	bytes := make([]byte, 2)
 	val := reflect.ValueOf(typ{})
 	b.ResetTimer()
@@ -101,7 +101,7 @@ func BenchmarkBool16Fields(b *testing.B) {
 		F1, F2, F3, F4, F5, F6, F7, F8, F9, F10, F11, F12, F13, F14, F15, F16 bool
 	}
 
-	p := makePackerWrapper(reflect.TypeOf(typ{}))
+	p, _ := makePackerWrapper(reflect.TypeOf(typ{}))
 	bytes := make([]byte, 2)
 	val := reflect.ValueOf(typ{})
 	b.ResetTimer()
@@ -396,7 +396,7 @@ func BenchmarkUseEmptyPacker(b *testing.B) {
 	}
 
 	t := reflect.TypeOf(typ{})
-	p := makePackerWrapper(t)
+	p, _ := makePackerWrapper(t)
 	bytes := make([]byte, 0)
 	val := reflect.ValueOf(typ{})
 	b.ResetTimer()
@@ -411,7 +411,7 @@ func BenchmarkUsePacker1Field(b *testing.B) {
 	}
 
 	t := reflect.TypeOf(typ{})
-	p := makePackerWrapper(t)
+	p, _ := makePackerWrapper(t)
 	bytes := make([]byte, 1)
 	val := reflect.ValueOf(typ{})
 	b.ResetTimer()
@@ -426,7 +426,7 @@ func BenchmarkUsePacker2Fields(b *testing.B) {
 	}
 
 	t := reflect.TypeOf(typ{})
-	p := makePackerWrapper(t)
+	p, _ := makePackerWrapper(t)
 	bytes := make([]byte, 2)
 	val := reflect.ValueOf(typ{})
 	b.ResetTimer()
@@ -441,7 +441,7 @@ func BenchmarkUsePacker4Fields(b *testing.B) {
 	}
 
 	t := reflect.TypeOf(typ{})
-	p := makePackerWrapper(t)
+	p, _ := makePackerWrapper(t)
 	bytes := make([]byte, 4)
 	val := reflect.ValueOf(&typ{}).Elem()
 	b.ResetTimer()
@@ -456,7 +456,7 @@ func BenchmarkUsePacker8Fields(b *testing.B) {
 	}
 
 	t := reflect.TypeOf(typ{})
-	p := makePackerWrapper(t)
+	p, _ := makePackerWrapper(t)
 	bytes := make([]byte, 8)
 	val := reflect.ValueOf(typ{})
 	b.ResetTimer()
@@ -471,7 +471,7 @@ func BenchmarkUsePacker8FieldsSigned(b *testing.B) {
 	}
 
 	t := reflect.TypeOf(typ{})
-	p := makePackerWrapper(t)
+	p, _ := makePackerWrapper(t)
 	bytes := make([]byte, 8)
 	val := reflect.ValueOf(typ{})
 	b.ResetTimer()
@@ -576,7 +576,7 @@ func BenchmarkNested1Level(b *testing.B) {
 	}
 
 	t := reflect.TypeOf(typ{})
-	p := makePackerWrapper(t)
+	p, _ := makePackerWrapper(t)
 	bytes := make([]byte, 0)
 	val := reflect.ValueOf(&typ{}).Elem()
 	b.ResetTimer()
@@ -594,7 +594,7 @@ func BenchmarkNested2Levels(b *testing.B) {
 	}
 
 	t := reflect.TypeOf(typ{})
-	p := makePackerWrapper(t)
+	p, _ := makePackerWrapper(t)
 	bytes := make([]byte, 0)
 	val := reflect.ValueOf(&typ{}).Elem()
 	b.ResetTimer()
@@ -616,7 +616,7 @@ func BenchmarkNested4Levels(b *testing.B) {
 	}
 
 	t := reflect.TypeOf(typ{})
-	p := makePackerWrapper(t)
+	p, _ := makePackerWrapper(t)
 	bytes := make([]byte, 0)
 	val := reflect.ValueOf(&typ{}).Elem()
 	b.ResetTimer()
@@ -646,7 +646,7 @@ func BenchmarkNested8Levels(b *testing.B) {
 	}
 
 	t := reflect.TypeOf(typ{})
-	p := makePackerWrapper(t)
+	p, _ := makePackerWrapper(t)
 	bytes := make([]byte, 0)
 	val := reflect.ValueOf(&typ{}).Elem()
 	b.ResetTimer()

--- a/gopack-impl.go
+++ b/gopack-impl.go
@@ -13,26 +13,16 @@ import (
 type packer func(b []byte, v reflect.Value)
 type unpacker func(b []byte, v reflect.Value)
 
-func makePackerWrapper(strct reflect.Type) packer {
+func makePackerWrapper(strct reflect.Type) (packer, int) {
 	p, bits, err := makePacker(0, strct)
 	if err != nil {
-		return func(b []byte, v reflect.Value) {
-			panic(err)
-		}
+		panic(err)
 	}
 	bytes := int(bits) / 8
 	if bits%8 != 0 {
 		bytes++
 	}
-	return func(b []byte, v reflect.Value) {
-		if len(b) < bytes {
-			panic(Error{fmt.Errorf("gopack: buffer too small (%v; need %v)", len(b), bytes)})
-		}
-		for i := 0; i < bytes; i++ {
-			b[i] = 0
-		}
-		p(b, v)
-	}
+	return p, bytes
 }
 
 func makeUnpackerWrapper(strct reflect.Type) unpacker {

--- a/gopack.go
+++ b/gopack.go
@@ -72,20 +72,24 @@ var unpackerCache struct {
 //	}
 func Pack(b []byte, strct interface{}) {
 	v := reflect.ValueOf(strct)
+	p := packerFor(v)
+	p(b, v)
+}
+
+func packerFor(v reflect.Value) packer {
 	typ := v.Type()
 	packerCache.RLock()
 	p, ok := packerCache.m[typ]
 	packerCache.RUnlock()
 	if ok {
-		p(b, v)
-		return
+		return p
 	}
 
 	p = makePackerWrapper(typ)
 	packerCache.Lock()
 	packerCache.m[typ] = p
 	packerCache.Unlock()
-	p(b, v)
+	return p
 }
 
 // Unpack the data in b into the fields of strct.


### PR DESCRIPTION
This makes it easier to write generic code that uses gopack under the hood without having to hardcode the size of the structs being used by the generic code.

This change also removes a layer of indirection in `makePackerWrapper`, by having the code check the input buffer is big enough directly in `Pack()` rather than via an extra anonymous func, which improves most encoding benchmarks by 4 to 6% (the gains are really modest in absolute terms, on the order of a few cycles, as all it's doing really is just removing an extra indirect function call).
